### PR TITLE
:heavy_plus_sign: (wiki) add libzip-dev dep

### DIFF
--- a/wiki/Dockerfile
+++ b/wiki/Dockerfile
@@ -6,6 +6,7 @@ RUN set -x; \
     apt-get update \
  && apt-get install -y --no-install-recommends \
     git \
+    libzip-dev \
     unzip \
     zlib1g-dev \
  && docker-php-ext-install \


### PR DESCRIPTION
PHP is dropping the bundled libzip and switching to using the os provided libzip. This PR prepares us to merge #23.