### PR TITLE
fix: update to smw 4.0.2

### DIFF
--- a/wiki/Dockerfile
+++ b/wiki/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer
 
 # Install composer based extensions
 RUN cd /var/www/html/ \
- && composer require mediawiki/semantic-media-wiki "~4.0" --update-no-dev \
+ && composer require mediawiki/semantic-media-wiki "~4.0.2" --update-no-dev \
  && rm composer.lock \
  && composer require mediawiki/semantic-result-formats "~4.0" --update-no-dev \
  && composer require mediawiki/semantic-compound-queries "~2.2" --update-no-dev \


### PR DESCRIPTION
This recent SMW release fixes a security issue and improves 1.38 compatibility paving the way to merging #92 

See [here](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/releasenotes/RELEASE-NOTES-4.0.2.md) for SMW release notes.