### PR TITLE
fix(db): make everything configuable via env

### DIFF
--- a/wiki/Dockerfile
+++ b/wiki/Dockerfile
@@ -36,12 +36,6 @@ RUN cd /var/www/html/ \
 # Install extensions with a git based install
 RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/mediawiki/extensions/ExternalData.git /var/www/html/extensions/ExternalData
 
-# Use a version from the main branch that can be loaded with wfLoadExtension
-# TODO remove after >v2.1 is release, probably in mw 1.38
-RUN    git clone https://github.com/wikimedia/mediawiki-extensions-SemanticDrilldown.git /var/www/html/extensions/SemanticDrilldown \
-    && cd /var/www/html/extensions/SemanticDrilldown \
-    && git reset --hard f59cae7785ecafc10cd42e289c06232a9d34e1fe
-
 RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/mediawiki/extensions/PageForms.git /var/www/html/extensions/PageForms
 
 RUN git clone --depth=1 -b $MEDIAWIKI_EXT_BRANCH https://gerrit.wikimedia.org/r/mediawiki/extensions/Arrays.git /var/www/html/extensions/Arrays

--- a/wiki/LocalSettings.php
+++ b/wiki/LocalSettings.php
@@ -65,20 +65,20 @@ $wgEnotifWatchlist = false; # UPO
 $wgEmailAuthentication = true;
 
 ## Database settings
-$wgDBtype = "mysql";
-$wgDBserver = "mysql";
-$wgDBname = "mediawiki";
+$wgDBtype = getenv("MW_WG_DBTYPE") ?: "mysql";
+$wgDBserver = getenv("MW_WG_DBSERVER") ?: "mysql";
+$wgDBname = getenv("MW_WG_DBNAME") ?: "mediawiki";
 $wgDBuser = getenv('MW_WG_DBUSER');
 $wgDBpassword = getenv('MW_WG_DBPASS');
 
 # MySQL specific settings
-$wgDBprefix = "";
+$wgDBprefix = getenv("MW_WG_DBPREFIX") ?: "";
 
 # MySQL table options to use during installation or update
-$wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=utf8";
+$wgDBTableOptions = getenv("MW_WG_DBTABLEOPTIONS") ?: "ENGINE=InnoDB, DEFAULT CHARSET=utf8";
 
 # Experimental charset support for MySQL 5.0.
-$wgDBmysql5 = true;
+$wgDBmysql5 = getenv("MW_WG_DBMYSQL5") ? (bool) getenv("MW_WG_DBMYSQL5") : true;
 
 ## Shared memory settings
 $wgMainCacheType = CACHE_NONE;
@@ -222,7 +222,6 @@ if (getenv('MW_EXTERNALDATA_DIRECTORY_PATH')) {
 wfLoadExtension( 'SemanticMediaWiki' );
 enableSemantics(getenv('MW_SMW_ENABLE_SEMANTICS_DOMAIN'));
 wfLoadExtension( 'SemanticCompoundQueries' );
-wfLoadExtension( 'SemanticDrilldown' );
 wfLoadExtension( 'PageForms' );
 
 # HierarchyBuilder Extension


### PR DESCRIPTION
Our new infrastructure needs more flexibility. I'm also removing the Semantic-Drilldown Extension after having checked that  it doesn't seem to be in the critical path. We can re-introduce it later if we want to.

* [kanboard task](https://board.rabe.ch/project/9/task/816)