### PR TITLE
fix: Update MW from 1.39.10 to 1.39.11

### DIFF
--- a/wiki/Dockerfile
+++ b/wiki/Dockerfile
@@ -1,4 +1,4 @@
-FROM mediawiki:1.39.10 AS build
+FROM mediawiki:1.39.11 AS build
 
 ENV MEDIAWIKI_EXT_BRANCH=REL1_39
 


### PR DESCRIPTION
Replaces https://github.com/radiorabe/docker-mediawiki/pull/260 because we can't update without proper testing as per https://github.com/radiorabe/docker-mediawiki/issues/265